### PR TITLE
Update _sidebar.md spelling of the reference for the document corrected

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
The reference for the document doc-references.md was incorrect. It was previously written as **doc-references__.md**